### PR TITLE
set default log socket non-blocking and other cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udp-logger-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 authors = ["Bruce Brown <brown.bruce1207@gmail.com>"]
@@ -17,7 +17,6 @@ repository = "https://github.com/brucebrown/udp-logger-rs"
 log = { version = "0.4", features = ["std", "kv_unstable_std"] }
 chrono = { version = "0.4", features = ["std"] }
 bytebuffer = "0.2"
-libflate = "1.1"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ Log macro for log's kv-unstable backend.
 - [Crates.io][2]
 - [Releases][releases]
 
+## Motivation
+I wanted to build key/value context into my structs and log it when logging within an impl fn.
+Beyond that, I also wanted to separate the responsiblity of logging from log file management and any
+associated business logic.
+
+Consider an architecture with multiple containers running on the same host. One being a
+server, the other being a log processor. Through this separation, the server performs logging and
+is insulated from the processing of that logging. Meanwhile, the log processor determines
+how log messages are processed, which can itself become quite complex.
+
+Additionally, I decided that one might want to map the log level to a source port, and/or destination port.
+The thought here is that it might simplify processing, as the source and/or destination port
+implies the log level.
+
+Finally, by separating them, server development can use a different log processor than production and
+production log processing can be tested independent of the server.
+
 ## Examples
 ```rust
 use udp_logger_rs::info;
@@ -23,6 +40,29 @@ fn main() {
         ("cat_2".into(), "nori".into()),
     ];
     info!(kvs: &ctx, "hello {}", "cats",);
+}
+```
+
+The UDP client can be as trivial as:
+```rust
+use smol::Async;
+use std::io::{self};
+use std::net::UdpSocket;
+
+fn main() -> io::Result<()> {
+    let _result = futures_lite::future::block_on(async {
+        let socket = Async::<UdpSocket>::bind(([127, 0, 0, 1], 4010))?;
+        let mut buf = [0u8; 1024 * 32];
+        loop {
+            let (len, addr) = socket.recv_from(&mut buf).await?;
+            let logmsg = std::str::from_utf8(&buf[..len]).expect("invalid utf8");
+            println!("{} from={}", logmsg, addr);
+        }
+        // This hack of unreachable code cements the return type
+        #[allow(unreachable_code)]
+        io::Result::Ok(())
+    });
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
While with_source() and with_source_level() set the socket non-blocking, new() did not set the default socket non-blocking, it is now set to non-blocking.

There were a few lingering .unwrap() which have now been converted into appropriate error handling.

Cleaned up wire format compression. There were some unwraps and missing result testing.

Added trivial UDP socket client to README

Add a Motivation section to README
Update the version to 0.1.4
Make the examples a bit more meaningful

Remove Deflated wire format

For the most part, the compression algorithms reduced the log payload by 10% or less, often 0%. I looked at some small string compression and it wasn't much better. In the end I decided that the compression wasn't worth the CPU cycles and have removed Deflated as a wire format.